### PR TITLE
Bugfix: Set dropdown header text to current item

### DIFF
--- a/Bootstrap.renderer.php
+++ b/Bootstrap.renderer.php
@@ -460,11 +460,11 @@
 	private function makePathTogglable( $path, $tagType ) {
 		$finder = new DOMXPath( $this->doc );
 
-		foreach( $finder->query( $path ) as $header ) {
+		foreach( $finder->query( $path ) as $key=>$header ) {
 			
 			// get the single text value 
 			if( $header->nodeType != 3 ) { // if not a textnode
-				$headerText = $finder->query( $path . '/text()')->item(0);
+				$headerText = $finder->query( $path . '/text()')->item($key);
 				$headerTextValue = $headerText->nodeValue;
 			} else
 				$headerTextValue = $header->nodeValue;


### PR DESCRIPTION
Bug: if navbar has multiple dropdowns, the header text for each dropdown is set to that of the first navbar element, instead of the current element.
