### PR TITLE
Added closing brace for media query.

### DIFF
--- a/assets/mediawiki.css
+++ b/assets/mediawiki.css
@@ -147,3 +147,4 @@ a.new {
                     background-color: #0088cc;
                     color: #ffffff;
                 }
+            }


### PR DESCRIPTION
Anything added in assets/site.css would fall under this media query, since it wasn't closed.  Closing it in this css file fixes it.
